### PR TITLE
Add .travis.yml

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,2 @@
 # Changes
 
-
-# Checklist
-- [ ] Spelling is good
-- [ ] `make` or `make lint` ran successfully

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-language: generic 
 install:
     - gem install mdl
 script:
     - mdl .
+notifications:
+    email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: generic 
+install:
+    - gem install mdl
+script:
+    - mdl .


### PR DESCRIPTION
# Changes

Adds a .travis.yml that should install and run `mdl`. Note that the `generic` image on Travis CI should have Ruby preinstalled.

Closes #19.

# Checklist
- [x] Spelling is good
- [x] `make` or `make lint` ran successfully