### PR TITLE
Add pre-commit hook

### DIFF
--- a/.hooks/README.md
+++ b/.hooks/README.md
@@ -1,0 +1,6 @@
+# Docs/Hooks
+
+Install these git pre-commit hooks by
+moving them to `.git/hooks`. Note that
+at the moment they will only work with
+bash.

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+mdl .


### PR DESCRIPTION
Adds a pre-commit hook to run `mdl .` before allowing commits. These can't be enforced (hence we still should use Travis) but I'm quite fond of them.