### PR TITLE
Add link to Ideas repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ for documentation and discussion. Note that these are all private to
 the `ubclaunchpad` GitHub organization; if you have not been added to
 the org, talk to your Tech Lead or one of the Presidents.
 
-* [Strategy](https://github.com/ubclaunchpad/strategy): The main repo
-  for the strategy team, containing sponsorship-related discussion.
-* [Design](https://github.com/ubclaunchpad/design): The main repo for
-  the design team, containing Launch Pad graphical assets and
-  design-related discussion.
-* [Tech Leads](https://github.com/ubclaunchpad/tech-leads): A repo for
-  Tech Lead-specific content, such as meeting notes. Note that this
-  repo is only visible to Tech Leads.
+* [Ideas](https://github.com/ubclaunchpad/ideas): The goal of this repository is
+  to be a place where anyone in Launch Pad can submit ideas for anything - how
+  to improve Launch Pad, potential projects, event ideas... anything you want!
+* [Strategy](https://github.com/ubclaunchpad/strategy): The main repo for the
+  strategy team, containing sponsorship-related discussion.
+* [Design](https://github.com/ubclaunchpad/design): The main repo for the design
+  team, containing Launch Pad graphical assets and design-related discussion.
+* [Tech Leads](https://github.com/ubclaunchpad/tech-leads): A repo for Tech
+  Lead-specific content, such as meeting notes. Note that this repo is only
+  visible to Tech Leads.


### PR DESCRIPTION
# Related Tickets

n/a

# Changes

Adds a link to the new Ideas repo, and some formatting adjustments to the `Other Repos` section
