### PR TITLE
add fathom analytics

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -56,7 +56,7 @@ module.exports = {
 
     // analytics are under team@ubclaunchpad.com, property docs.ubclaunchpad.com
     // dashboard: https://app.usefathom.com/share/oemmhhle/docs.ubclaunchpad.com
-    ['@ubclaunchpad/vuepress-fathom', {
+    ['@ubclaunchpad/fathom', {
       'siteID': 'OEMMHHLE',
     }],
   ],

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -53,5 +53,11 @@ module.exports = {
     ['@vuepress/google-analytics', {
       'ga': 'UA-63529563-2',
     }],
+
+    // analytics are under team@ubclaunchpad.com, property docs.ubclaunchpad.com
+    // dashboard: https://app.usefathom.com/share/oemmhhle/docs.ubclaunchpad.com
+    ['@ubclaunchpad/vuepress-fathom', {
+      'siteID': 'OEMMHHLE',
+    }],
   ],
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "markdownlint . --ignore node_modules --ignore index.md"
   },
   "dependencies": {
+    "@ubclaunchpad/vuepress-fathom": "^1.0.0",
     "@vuepress/plugin-back-to-top": "^1.4.1",
     "@vuepress/plugin-google-analytics": "^1.4.1",
     "markdownlint": "^0.20.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "markdownlint . --ignore node_modules --ignore index.md"
   },
   "dependencies": {
-    "@ubclaunchpad/vuepress-fathom": "^1.0.0",
+    "@ubclaunchpad/vuepress-plugin-fathom": "^1.1.0",
     "@vuepress/plugin-back-to-top": "^1.4.1",
     "@vuepress/plugin-google-analytics": "^1.4.1",
     "markdownlint": "^0.20.2",


### PR DESCRIPTION
similar to https://github.com/ubclaunchpad/ubclaunchpad.com/pull/170 - similarly, no existing package exists so I made [`@ubclaunchpad/vuepress-plugin-fathom`](https://github.com/ubclaunchpad/vuepress-plugin-fathom)

see the dashboard here: https://app.usefathom.com/share/oemmhhle/docs.ubclaunchpad.com

since this is just for tracking page views, thinking of getting rid of google analytics and using fathom instead