### PR TITLE
add more links to workflows

### DIFF
--- a/handbook/onboarding/design.md
+++ b/handbook/onboarding/design.md
@@ -17,7 +17,7 @@ See [our Slack guide](/handbook/tools/slack.md) for more details.
 
 ### GitHub Teams
 
-Make sure you are a part of the GitHub team [`@ubclaunchpad/design`](https://github.com/orgs/ubclaunchpad/teams/design), and check that you have access to the [Design repository](https://github.com/ubclaunchpad/design).
+Make sure you are a part of the GitHub team [`@ubclaunchpad/design`](https://github.com/orgs/ubclaunchpad/teams/design), and check that you have access to the [Design repository](https://github.com/ubclaunchpad/design) - this repository contains (some) design assets, resources, and tracking issues.
 
 ::: tip
 Make sure that you are **watching** all relevant repositories so that you don't miss any updates! To learn more about setting up your GitHub notifcations, check our [GitHub guide](../tools/github.md#setting-up-notifications).

--- a/handbook/onboarding/design.md
+++ b/handbook/onboarding/design.md
@@ -33,4 +33,11 @@ TODO
 
 ## Workflows
 
+::: tip
+We use GitHub and Slack for pretty much *everything* - make sure you are intimately familiar with **both**, regardless of your role, by reading our handcrafted guides:
+
+* [GitHub guide](https://docs.ubclaunchpad.com/handbook/tools/github)
+* [Slack guide](https://docs.ubclaunchpad.com/handbook/tools/slack)
+:::
+
 TODO: how the Design team will use handbook / GitHub / Drive / Figma etc.

--- a/handbook/onboarding/everyone.md
+++ b/handbook/onboarding/everyone.md
@@ -39,6 +39,10 @@ Make sure you are part of the [UBC Launch Pad GitHub organization](https://githu
   * If you can't see the Ideas repository, check that you are in the GitHub team [`@ubclaunchpad/all`](https://github.com/orgs/ubclaunchpad/teams/all) - if not,make sure you've [set up your profile on Rocket](#rocket-setup)!
 * Read our [Intro to GitHub](../tools/github.md) guide, which will help you get started on leveraging GitHub and setting up notifications.
 
+### Drive Access
+
+Make sure you have access to our [Projects Folder](https://drive.google.com/drive/u/0/folders/18piFDBdAUuZAOf9xOgpf2_HBUuVNae0S) on Google Drive - this is where your team's loose documents will live!
+
 ## Further Actions
 
 If you've got everything set up, congratulations - you are pretty much good to go! Make sure you take some time to get to know this website - it should contain everything you need to know to kickstart your time with Launch Pad, and if anything is missing please [let us know](https://github.com/ubclaunchpad/docs/issues/new)!

--- a/handbook/onboarding/leads.md
+++ b/handbook/onboarding/leads.md
@@ -36,8 +36,9 @@ Make sure all leads are given "editor" access to the [shared Launch Pad folder](
 Within the shared Launch Pad folder, try to maintain the following structure:
 
 * [Projects](https://drive.google.com/drive/u/0/folders/18piFDBdAUuZAOf9xOgpf2_HBUuVNae0S) - folders for project teams
+  * Note that everyone should be granted access to this folder (part of [Onboarding for Everyone](../onboarding/everyone.md))
   * Each tech lead should create a folder for their project inside a year subfolder ("Projects YYYY") of this folder
-  * Inside each project folder, each lead should create a document for meeting notes. All their project meetings should go in this document. See [Sprint Planning](../project-management/sprints.md) for more details. When teams are formed, make sure each folder is shared with all team members.
+  * Inside each project folder, each lead should create a document for meeting notes. All their project meetings should go in this document. See [Sprint Planning](../project-management/sprints.md) for more details.
 * [Strategy](https://drive.google.com/drive/u/0/folders/0BwdNv1PZjDeXMkc1eDVNY1ZHT00) - see [Onboarding for Strategy](./strategy.md)
 * [Design](https://drive.google.com/drive/u/0/folders/1Zfe25r3D77hGdyMkj0tlxHNa-r7fAq1d) - see [Onboarding for Design](./design.md)
 * [Leads](https://drive.google.com/drive/u/0/folders/1hgPcUC_DrFMmzZ04pBSlZFig4v9AbTuv) - that's for us!

--- a/handbook/onboarding/leads.md
+++ b/handbook/onboarding/leads.md
@@ -19,11 +19,11 @@ As a lead, you should also lead in Slack participation by example - please make 
 
 Make sure you are a part of:
 
-* [`@ubclaunchpad/leads`](https://github.com/orgs/ubclaunchpad/teams/leads), and check that you can access the [Leads repository](https://github.com/ubclaunchpad/leads)
-* [`@ubclaunchpad/strategy`](https://github.com/orgs/ubclaunchpad/teams/strategy), and check that you can access the [Strategy repository](https://github.com/ubclaunchpad/strategy)
-* [`@ubclaunchpad/design`](https://github.com/orgs/ubclaunchpad/teams/design), and check that you can access the [Design repository](https://github.com/ubclaunchpad/design)
+* [`@ubclaunchpad/leads`](https://github.com/orgs/ubclaunchpad/teams/leads), and check that you can access the [Leads repository](https://github.com/ubclaunchpad/leads) - this repository primarily contains interview resources and other leads tasks
+* [`@ubclaunchpad/strategy`](https://github.com/orgs/ubclaunchpad/teams/strategy), and check that you can access the [Strategy repository](https://github.com/ubclaunchpad/strategy) - this repository contains sponsorship resources and event/sponsorship tracking issues
+* [`@ubclaunchpad/design`](https://github.com/orgs/ubclaunchpad/teams/design), and check that you can access the [Design repository](https://github.com/ubclaunchpad/design) - this repository contains (some) design assets, resources, and other tasks
 
-Additional, the president(s) should also be a part of [`@ubclaunchpad/exec`](https://github.com/orgs/ubclaunchpad/teams/exec) and familiarize themselves with the [Exec repository](https://github.com/ubclaunchpad/exec), where we keep track of accounts and credentials.
+Additionally, the presidents should also be a part of [`@ubclaunchpad/exec`](https://github.com/orgs/ubclaunchpad/teams/exec) and familiarize themselves with the [Exec repository](https://github.com/ubclaunchpad/exec), where we keep track of accounts and credentials.
 
 ::: tip
 Make sure that you are **watching** all relevant repositories so that you don't miss any updates! To learn more about setting up your GitHub notifcations, check our [GitHub guide](../tools/github.md#setting-up-notifications).
@@ -33,8 +33,38 @@ Make sure that you are **watching** all relevant repositories so that you don't 
 
 Make sure all leads are given "editor" access to the [shared Launch Pad folder](https://drive.google.com/drive/folders/1u-U3w0V0MaLQrWtDdw_8n15V2lO-6gXo), which is owned by the `team@ubclaunchpad.com` account (more details are in the [Exec repository](https://github.com/ubclaunchpad/exec)).
 
-TODO: detailed drive hierarchy
+Within the shared Launch Pad folder, try to maintain the following structure:
+
+* [Projects](https://drive.google.com/drive/u/0/folders/18piFDBdAUuZAOf9xOgpf2_HBUuVNae0S) - folders for project teams
+  * Each tech lead should create a folder for their project inside a year subfolder ("Projects YYYY") of this folder
+  * Inside each project folder, each lead should create a document for meeting notes. All their project meetings should go in this document. See [Sprint Planning](../project-management/sprints.md) for more details. When teams are formed, make sure each folder is shared with all team members.
+* [Strategy](https://drive.google.com/drive/u/0/folders/0BwdNv1PZjDeXMkc1eDVNY1ZHT00) - see [Onboarding for Strategy](./strategy.md)
+* [Design](https://drive.google.com/drive/u/0/folders/1Zfe25r3D77hGdyMkj0tlxHNa-r7fAq1d) - see [Onboarding for Design](./design.md)
+* [Leads](https://drive.google.com/drive/u/0/folders/1hgPcUC_DrFMmzZ04pBSlZFig4v9AbTuv) - that's for us!
+  * Leads should create a document for meeting notes titled "Leads: Meeting Notes YYYY". All leads meetings should go in this document.
+* [Exec](https://drive.google.com/drive/u/0/folders/10b_2H5EhPpJtdgNi7QizRhWC9Qtivr8L) - for the presidents
+  * Presidents should create a document for meeting notes titled "Exec: Meeting Notes YYYY". All exec meetings should go in this document.
 
 ## Workflows
 
-TODO: how leads will use handbook / GitHub / Drive etc.
+::: tip
+We use GitHub and Slack for pretty much *everything* - make sure you are intimately familiar with **both**, regardless of your role, by reading our handcrafted guides:
+
+* [GitHub guide](https://docs.ubclaunchpad.com/handbook/tools/github)
+* [Slack guide](https://docs.ubclaunchpad.com/handbook/tools/slack)
+:::
+
+### Projects
+
+The handbook's Project Management pages are a must-read - for all leads:
+
+* [Scope](../project-management/scope.md) - how to develop and scope ideas for Launch Pad projects, as well as the timeline for development
+* [Sprints](../project-management/sprints.md) - how to plan and collaborate with your team to deliver on your project
+
+Additionally, technical leads will want to take a look at the [Repository Management](https://docs.ubclaunchpad.com/handbook/project-management/repositories) page to help them set up tooling for their projects.
+
+### Meetings
+
+Leads meetings between all leads (technical and non-technical) should happen on a regular basis.
+
+TODO: flesh out what we want meetings to be like

--- a/handbook/onboarding/leads.md
+++ b/handbook/onboarding/leads.md
@@ -17,11 +17,11 @@ As a lead, you should also lead in Slack participation by example - please make 
 
 ### GitHub Teams
 
-Make sure you are a part of:
+Make sure you are a part of the following teams on GitHub:
 
-* [`@ubclaunchpad/leads`](https://github.com/orgs/ubclaunchpad/teams/leads), and check that you can access the [Leads repository](https://github.com/ubclaunchpad/leads) - this repository primarily contains interview resources and other leads tasks
+* [`@ubclaunchpad/leads`](https://github.com/orgs/ubclaunchpad/teams/leads), and check that you can access the [Leads repository](https://github.com/ubclaunchpad/leads) - this repository primarily contains interview resources and tracking issues
 * [`@ubclaunchpad/strategy`](https://github.com/orgs/ubclaunchpad/teams/strategy), and check that you can access the [Strategy repository](https://github.com/ubclaunchpad/strategy) - this repository contains sponsorship resources and event/sponsorship tracking issues
-* [`@ubclaunchpad/design`](https://github.com/orgs/ubclaunchpad/teams/design), and check that you can access the [Design repository](https://github.com/ubclaunchpad/design) - this repository contains (some) design assets, resources, and other tasks
+* [`@ubclaunchpad/design`](https://github.com/orgs/ubclaunchpad/teams/design), and check that you can access the [Design repository](https://github.com/ubclaunchpad/design) - this repository contains (some) design assets, resources, and tracking issues
 
 Additionally, the presidents should also be a part of [`@ubclaunchpad/exec`](https://github.com/orgs/ubclaunchpad/teams/exec) and familiarize themselves with the [Exec repository](https://github.com/ubclaunchpad/exec), where we keep track of accounts and credentials.
 

--- a/handbook/onboarding/strategy.md
+++ b/handbook/onboarding/strategy.md
@@ -29,6 +29,13 @@ Make sure all strategy members are given "editor" access to the [shared Launch P
 
 ## Workflows
 
+::: tip
+We use GitHub and Slack for pretty much *everything* - make sure you are intimately familiar with **both**, regardless of your role, by reading our handcrafted guides:
+
+* [GitHub guide](https://docs.ubclaunchpad.com/handbook/tools/github)
+* [Slack guide](https://docs.ubclaunchpad.com/handbook/tools/slack)
+:::
+
 ### Acquiring Sponsorships
 
 * Create a [Sponsorship tracking issue on GitHub](https://github.com/ubclaunchpad/strategy/issues/new?assignees=&labels=sponsorship&template=sponsorship.md&title=)

--- a/handbook/onboarding/strategy.md
+++ b/handbook/onboarding/strategy.md
@@ -1,8 +1,6 @@
 # 🚀 Onboarding for Strategy
 
-::: warning
-TODO
-:::
+Welcome to UBC Launch Pad, and congratulations (and thank you!) for joining the strategy team!
 
 ## Checklist
 

--- a/handbook/onboarding/strategy.md
+++ b/handbook/onboarding/strategy.md
@@ -17,7 +17,7 @@ See [our Slack guide](/handbook/tools/slack.md) for more details.
 
 ### GitHub Teams
 
-Make sure you are a part of [`@ubclaunchpad/strategy`](https://github.com/orgs/ubclaunchpad/teams/strategy), and check that you can access the [Strategy repository](https://github.com/ubclaunchpad/strategy).
+Make sure you are a part of the GitHub team [`@ubclaunchpad/strategy`](https://github.com/orgs/ubclaunchpad/teams/strategy), and check that you can access the [Strategy repository](https://github.com/ubclaunchpad/strategy) - this repository contains sponsorship resources and event/sponsorship tracking issues.
 
 ::: tip
 Make sure that you are **watching** all relevant repositories so that you don't miss any updates! To learn more about setting up your GitHub notifcations, check our [GitHub guide](../tools/github.md#setting-up-notifications).

--- a/handbook/project-management/sprints.md
+++ b/handbook/project-management/sprints.md
@@ -26,7 +26,9 @@ During each sprint, each member should have a few assigned tasks to work on - th
 
 Sprint meetings should be conducted at the very start or end of each sprint. Most sprint meetings should have the following structure - we've also provided some guidance on roughly how long each step should take, though this will vary per team.
 
-1. 📝 **Prep:** 1-2 days before your meeting, create a document outlining all of the following parts of the meeting in a few words per point.
+At the start of the project, the lead should have created a project folder in Google Drive with a meeting document and shared it with their team - ask your lead if you don't have access to your team's meeting notes and project folder.
+
+1. 📝 **Prep:** 1-2 days before your meeting, update your meeting document to outline all of the following parts of the meeting in a few words per point.
    * The goal is to have everyone briefly think about what they've achieved and problems they've faced so that meetings can run more smoothly!
    * A good way to do this is to have a document posted to your team's Slack channel so everyone can add to it at their leisure before you meeting
 2. ✈️ **Overview:** At the start of the meeting, the lead gives general updates or comments overall progress (~1-2 minutes)


### PR DESCRIPTION
### Related Tickets

<!-- List relevant tickets, e.g. 'Closes #<some_ticket_number>' -->

n/a

### Changes

<!-- Briefly describe the changes you made -->

Adds a bunch of links to help make the onboarding section more useful.

Most notably, the Leads onboarding should have the specific links and setup that we want everyone to look at during the upcoming Leads kickoff meeting

I've also added some more aggressive hints to read the GitHub and Slack guides 🙃 

https://deploy-preview-83--ubclaunchpad-docs.netlify.app/handbook/onboarding/leads