### PR TITLE
strip leading emoji from header anchors

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -1,3 +1,13 @@
+const vuepressUtils = require('@vuepress/shared-utils');
+const emojiRegex = require('emoji-regex')();
+
+// custom slugify function to extend the default one by stripping out leading emoji
+const slugify = (s) => {
+  return vuepressUtils.slugify(s)
+    .replace(emojiRegex, '')
+    .replace(/^(\-)/, '');
+}
+
 module.exports = {
   // header properties
   title: 'UBC Launch Pad Documentation',
@@ -37,6 +47,12 @@ module.exports = {
       colorThemes: [],
       disableThemeIgnore: true,
     },
+  },
+
+  // markdown features
+  markdown: {
+    slugify,
+    anchor: { permalink: true, permalinkBefore: true, permalinkSymbol: '#', slugify }
   },
 
   plugins: [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ While the [Easy Way](#the-easy-way) is good for small changes, writing larger ch
    git checkout -b my-new-branch
    ```
 2. Make changes and commit them (make sure you have [good commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)!)
+   * We recommend using [Visual Studio Code](https://code.visualstudio.com/).
 3. Run `npm install` and `npm run lint` to ensure your code follows our style rules.
    * (optional) run `npm run serve` to test out the updated website locally!
 4. Push your local branch to the remote repository using `git push origin HEAD`
@@ -60,6 +61,7 @@ npm run serve    # runs the website locally
   <Badge type="tip" text="new"/>
   ```
 * Images should go in a `/img` folder in the same directory.
+* Headers can *start* with emoji, but don't put emojis anywhere else in a header!
 
 ## VuePress
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@ubclaunchpad/vuepress-plugin-fathom": "^1.1.0",
     "@vuepress/plugin-back-to-top": "^1.4.1",
     "@vuepress/plugin-google-analytics": "^1.4.1",
+    "emoji-regex": "^9.0.0",
     "markdownlint": "^0.20.2",
     "markdownlint-cli": "^0.22.0",
     "vuepress": "^1.4.1",


### PR DESCRIPTION
### Related Tickets

<!-- List relevant tickets, e.g. 'Closes #<some_ticket_number>' -->

n/a

### Changes

<!-- Briefly describe the changes you made -->

makes header links much easier to deal with by stripping out leading unicode emoji

e.g. https://deploy-preview-86--ubclaunchpad-docs.netlify.app/handbook/#onboarding