### PR TITLE
adjust manifesto and add software engineering section

### DIFF
--- a/handbook/manifesto.md
+++ b/handbook/manifesto.md
@@ -41,7 +41,7 @@ The phrase is in our club name, but what does it mean? "Software engineering" as
 
 > Programming means getting a program working. You have a problem to solve, you write some code, you run it, you get your answer, you’re done. That’s programming, and that's difficult enough by itself. But what if that code has to keep working, day after day? What if five other programmers need to work on the code too? Then you start to think about version control systems, to track how the code changes over time and to coordinate with the other programmers. You add unit tests, to make sure bugs you fix are not reintroduced over time, not by you six months from now, and not by that new team member who’s unfamiliar with the code. You think about modularity and design patterns, to divide the program into parts that team members can work on mostly independently. You use tools to help you find bugs earlier. You look for ways to make programs as clear as possible, so that bugs are less likely. You make sure that small changes can be tested quickly, even in large programs. You're doing all of this because your programming has turned into **software engineering**.
 
-### For sponsors and partners
+### Sponsors and Partners
 
 #### What we offer
 

--- a/handbook/manifesto.md
+++ b/handbook/manifesto.md
@@ -51,10 +51,6 @@ TODO
 
 #### What we offer
 
-::: warning
-This needs to be fleshed out more, especially regarding who this section is aimed at.
-:::
-
 * **Talent Pool**: our members are students who went through a rigorous selection process, who are dedicated in advancing their skills, and are experienced in a professional working environment. Many of our past alumni went to top firms and are recognized by industry leaders.
 * **Brand/Product Awareness**: our members are always looking for tools to help them make cool things faster and better. They often take these tools into our future workplaces and projects.
 * **Innovative Ideas**: our members are problem-solvers across diverse backgrounds.

--- a/handbook/manifesto.md
+++ b/handbook/manifesto.md
@@ -43,6 +43,10 @@ The phrase is in our club name, but what does it mean? "Software engineering" as
 
 ### Sponsors and Partners
 
+Our club would not be what it is today without the help of our [partners and sponsors](https://ubclaunchpad.com/#sponsors), who provide us with the resources and tools to help our members learn and deliver on their projects and goals.
+
+If you are interested in working with us in any capacity, please feel free to reach out to us at [team@ubclaunchpad.com](team@ubclaunchpad.com) or refer to our [sponsorship package](https://ubclaunchpad.com/sponsorship)!
+
 #### What we offer
 
 * **Talent Pool**: our members are students who went through a rigorous selection process, who are dedicated in advancing their skills, and are experienced in a professional working environment. Many of our past alumni went to top firms and are recognized by industry leaders.

--- a/handbook/manifesto.md
+++ b/handbook/manifesto.md
@@ -1,14 +1,14 @@
 # 🔖 Manifesto
 
 ::: warning
-These documents are a work in progress.
+These sections are a work in progress.
 :::
 
 ## Vision <Badge type="tip" text="updated"/>
 
-This section is a guidance of what Launch Pad stands for, and how we can pitch Launch Pad to our potential partners and sponsors.
+This section provides guidance on what Launch Pad stands for.
 
-### Launch Pad’s Value Proposition
+### Our Value Proposition
 
 Technical advancements have created enormous opportunities in the world, people are capable for more than ever before. In this fast changing world, we want to provide a space for students who are passionate about technologies to develop their skills, to explore new possibilities, to share their expertise and learn from others, and to gain hands-on experience in building out what they envision.
 
@@ -35,43 +35,42 @@ As a club, Launch Pad supports every member’s experience through multiple ways
 3. We design team structure to enable mentorship and multidisciplinary teamwork from their peers
 4. We recruit with high standards to ensure everyone in Launch Pad is driven and dedicated in their own expertise
 
-### What We Offer
+#### What is Software Engineering?
+
+The phrase is in our club name, but what does it mean? "Software engineering" as a whole is pretty well summed up by this quote from a [blog post by Russ Cox](https://research.swtch.com/vgo-eng), one of the creators of the Go Programming Language:
+
+> Programming means getting a program working. You have a problem to solve, you write some code, you run it, you get your answer, you’re done. That’s programming, and that's difficult enough by itself. But what if that code has to keep working, day after day? What if five other programmers need to work on the code too? Then you start to think about version control systems, to track how the code changes over time and to coordinate with the other programmers. You add unit tests, to make sure bugs you fix are not reintroduced over time, not by you six months from now, and not by that new team member who’s unfamiliar with the code. You think about modularity and design patterns, to divide the program into parts that team members can work on mostly independently. You use tools to help you find bugs earlier. You look for ways to make programs as clear as possible, so that bugs are less likely. You make sure that small changes can be tested quickly, even in large programs. You're doing all of this because your programming has turned into **software engineering**.
+
+### For members
 
 ::: warning
-This needs to be fleshed out more.
+TODO
 :::
 
-#### Talent Pool
+### For sponsors and partners
 
-Our members are students who went through a rigorous selection process, who are dedicated in advancing their skills, and are experienced in a professional working environment. Many of our past alumni went to top firms and are recognized by industry leaders.
+#### What we offer
 
-#### Brand/Product Awareness
+::: warning
+This needs to be fleshed out more, especially regarding who this section is aimed at.
+:::
 
-Our members are always looking for tools for development.
+* **Talent Pool**: our members are students who went through a rigorous selection process, who are dedicated in advancing their skills, and are experienced in a professional working environment. Many of our past alumni went to top firms and are recognized by industry leaders.
+* **Brand/Product Awareness**: our members are always looking for tools to help them make cool things faster and better. They often take these tools into our future workplaces and projects.
+* **Innovative Ideas**: our members are problem-solvers across diverse backgrounds.
 
-#### Innovative Ideas
-
-Our members are problem-solvers across diversed backgrounds.
-
-### What We Need
+#### How you can support us
 
 We need long-term support on two fronts:
 
-#### Club Activities
-
-This includes everything from nice things like occasionally holding internal
+* **Club Activities**: this includes everything from nice things like occasionally holding internal
 events or food to improve team-bonding and productivity, to organizing workshops
 and external events that aim to raise awareness about Launch Pad and spread the
-expertise that some of our members have acquired.
-
-Events both external and internal are expensive, workshops take many hours to
+expertise that some of our members have acquired. Events both external and internal are expensive, workshops take many hours to
 organize and hold, but making sure we do these things on a regular basis is
 important for keeping morale up, improving productivity, and draw more people
 with an inclination to join Launch Pad to get involved.
-
-#### Services and Resources
-
-Many of our projects rely on servers, tools, and resources that are not free.
+* **Services and Resources**: many of our projects rely on servers, tools, and resources that are not free.
 We also try to find organization tools, teaching aides, etc. to help run Launch
 Pad better. All of this costs money, and the lack of funding means we have to
 shut down some cool projects. Continued, long-term investment in Launch Pad
@@ -79,6 +78,10 @@ helps us teach our members to use industry-standard tools and practices, as well
 as deploying awesome applications.
 
 ## Code of Conduct
+
+::: warning
+This section is outdated! TODO: update to reflect our current values
+:::
 
 All members must agree to and abide by the following policies:
 

--- a/handbook/manifesto.md
+++ b/handbook/manifesto.md
@@ -6,7 +6,7 @@ These sections are a work in progress.
 
 ## Vision <Badge type="tip" text="updated"/>
 
-This section provides guidance on what Launch Pad stands for.
+This section provides guidance on what Launch Pad stands for and what we offer.
 
 ### Our Value Proposition
 

--- a/handbook/manifesto.md
+++ b/handbook/manifesto.md
@@ -41,12 +41,6 @@ The phrase is in our club name, but what does it mean? "Software engineering" as
 
 > Programming means getting a program working. You have a problem to solve, you write some code, you run it, you get your answer, you’re done. That’s programming, and that's difficult enough by itself. But what if that code has to keep working, day after day? What if five other programmers need to work on the code too? Then you start to think about version control systems, to track how the code changes over time and to coordinate with the other programmers. You add unit tests, to make sure bugs you fix are not reintroduced over time, not by you six months from now, and not by that new team member who’s unfamiliar with the code. You think about modularity and design patterns, to divide the program into parts that team members can work on mostly independently. You use tools to help you find bugs earlier. You look for ways to make programs as clear as possible, so that bugs are less likely. You make sure that small changes can be tested quickly, even in large programs. You're doing all of this because your programming has turned into **software engineering**.
 
-### For members
-
-::: warning
-TODO
-:::
-
 ### For sponsors and partners
 
 #### What we offer


### PR DESCRIPTION
### Related Tickets

<!-- List relevant tickets, e.g. 'Closes #<some_ticket_number>' -->

follow-up to #87 

### Changes

<!-- Briefly describe the changes you made -->

* add back our old software engineering section because i still like the quote :))) sorry
* condensed current "what we offer / what we need" sections into a targeted "for sponsors" section

https://deploy-preview-90--ubclaunchpad-docs.netlify.app/handbook/manifesto