### PR TITLE
add custom fathomURL

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -112,7 +112,9 @@ module.exports = {
     // analytics are under team@ubclaunchpad.com, property docs.ubclaunchpad.com
     // dashboard: https://app.usefathom.com/share/oemmhhle/docs.ubclaunchpad.com
     ['@ubclaunchpad/fathom', {
-      'fathomURL': 'https://chinchilla.ubclaunchpad.com/script.js',
+      // TODO: replace with https://chinchilla.ubclaunchpad.com/script.js
+      // once https://github.com/unstacked/fathom-client/issues/5 is closed
+      'fathomURL': 'https://chinchilla.ubclaunchpad.com/tracker.js',
       'siteID': 'OEMMHHLE',
     }],
   ],

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -112,9 +112,7 @@ module.exports = {
     // analytics are under team@ubclaunchpad.com, property docs.ubclaunchpad.com
     // dashboard: https://app.usefathom.com/share/oemmhhle/docs.ubclaunchpad.com
     ['@ubclaunchpad/fathom', {
-      // TODO: replace with https://chinchilla.ubclaunchpad.com/script.js
-      // once https://github.com/unstacked/fathom-client/issues/5 is closed
-      'fathomURL': 'https://chinchilla.ubclaunchpad.com/tracker.js',
+      'fathomURL': 'https://chinchilla.ubclaunchpad.com/script.js',
       'siteID': 'OEMMHHLE',
     }],
   ],

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -112,6 +112,7 @@ module.exports = {
     // analytics are under team@ubclaunchpad.com, property docs.ubclaunchpad.com
     // dashboard: https://app.usefathom.com/share/oemmhhle/docs.ubclaunchpad.com
     ['@ubclaunchpad/fathom', {
+      'fathomURL': 'https://chinchilla.ubclaunchpad.com/script.js',
       'siteID': 'OEMMHHLE',
     }],
   ],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "markdownlint . --ignore node_modules --ignore index.md"
   },
   "dependencies": {
-    "@ubclaunchpad/vuepress-plugin-fathom": "^1.1.0",
+    "@ubclaunchpad/vuepress-plugin-fathom": "^1.2.1",
     "@vuepress/plugin-back-to-top": "^1.4.1",
     "@vuepress/plugin-google-analytics": "^1.4.1",
     "emoji-regex": "^9.0.0",


### PR DESCRIPTION
### Related Tickets

<!-- List relevant tickets, e.g. 'Closes #<some_ticket_number>' -->

n/a

### Changes

<!-- Briefly describe the changes you made -->

This allows us to dodge adblockers since nobody knows of the ubclauncpad.com domain. Neat fathom feature https://usefathom.com/support/custom-domains

blocked by https://github.com/unstacked/fathom-client/issues/5