### PR TITLE
add Fathom Analytics guidance

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -86,6 +86,7 @@ module.exports = {
         'slack',
         'github',
         'deployment',
+        'analytics',
       ],
       // automatically generate a sidebar for each page
       '/': 'auto',

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -21,7 +21,8 @@ We use a variety of technology and tools at Launch Pad - these sections help you
 
 * [**Slack**](./tools/slack.md): Best practices, channels, bots, and general information about our Slack workspace! Slack is where most Launch Pad discussions and announcements happen.
 * [**GitHub**](./tools/github.md): Guidance on getting started with our GitHub organization! GitHub is where we host, document, and manage the code in all our projects.
-* [**Deployment**](./tools/deployment.md): Launch Pad's specific advice regarding deployment and getting your project out to the world.
+* [**Deployment**](./tools/deployment.md): Launch Pad's recommendations regarding deployment and getting your project out to the world.
+* [**Analytics**](./tools/analytics.md): Launch Pad's recommendations regarding setting up analytics to see how users interact with your projects.
 * [**Other Tools**](../resources/tools.md): Our Resources section has a page on general tools you can leverage to help you build awesome stuff!
 
 ## 👨‍💼 Project Management <Badge type="tip" text="updated"/>

--- a/handbook/tools/analytics.md
+++ b/handbook/tools/analytics.md
@@ -13,7 +13,7 @@ Analytics are a fantastic way to get some concrete feedback on what users are do
 
 To get started, reach out to [`#ask-leads`](https://ubclaunchpad.slack.com/messages/CK935RD3Q/) to get a site and dashboard set up in Fathom - we will provide you with a site code and public dashboard.
 
-Using the site code, you get Fathom set up on your project! Note that we have a custom domain set up for our tracker script, `https://chinchilla.ubclaunchpad.com/script.js`, to avoid being blocked by adblockers (this is especially important given that Launch Pad projects are relatively low-traffic).
+Using the site code, you can now set up analytics on your project! Note that we have a custom domain set up for our tracker script, `https://chinchilla.ubclaunchpad.com/script.js`, to avoid being blocked by adblockers (this is especially important given that Launch Pad projects are relatively low-traffic).
 
 * Most projects can leverage the provided [code snippet](https://usefathom.com/support/tracking). Make sure you take a look at the [advanced options](https://usefathom.com/support/tracking-advanced) to make sure your snippet is configured correctly - for example, a good setup for a ReactJS project would be:
   ```html

--- a/handbook/tools/analytics.md
+++ b/handbook/tools/analytics.md
@@ -1,0 +1,25 @@
+# 📊 Analytics
+
+Analytics are a fantastic way to get some concrete feedback on what users are doing on your applications. Sometimes, you might be surprised to see that a project you think nobody uses actually gets a consistent trickle of traffic! This page documents some recommended ways you can set up analytics for your projects at Launch Pad.
+
+## Web Projects
+
+[Fathom Analytics](https://usefathom.com/) is a simple, lightweight web analytics service that we use in several Launch Pad projects. As a sponsor, they are currently providing us with a paid account to leverage for this purpose. Here are some dashboards for Launch Pad projects:
+
+* [`ubclaunchpad.com`](https://app.usefathom.com/share/ftsspsgr/ubclaunchpad.com)
+* [`docs.ubclaunchpad.com`](https://app.usefathom.com/share/oemmhhle/docs.ubclaunchpad.com)
+* [`sync.ubclaunchpad.com`](https://app.usefathom.com/share/lpvlowxe/sync.ubclaunchpad.com)
+* [`ubcsim2.ubclaunchpad.com`](https://app.usefathom.com/share/dymzbwsl/ubcsim2.ubclaunchpad.com)
+
+To get started, reach out to [`#ask-leads`](https://ubclaunchpad.slack.com/messages/CK935RD3Q/) to get a site and dashboard set up in Fathom - we will provide you with a site code and public dashboard.
+
+Using the site code, you get Fathom set up on your project! Note that we have a custom domain set up for our tracker script, `https://chinchilla.ubclaunchpad.com/script.js`, to avoid being blocked by adblockers (this is especially important given that Launch Pad projects are relatively low-traffic).
+
+* Most projects can leverage the provided [code snippet](https://usefathom.com/support/tracking). Make sure you take a look at the [advanced options](https://usefathom.com/support/tracking-advanced) to make sure your snippet is configured correctly - for example, a good setup for a ReactJS project would be:
+  ```html
+  <script src="https://chinchilla.ubclaunchpad.com/script.js" site="XXXXXXXX" spa="auto" excluded-domains="localhost" defer></script>
+  ```
+  See [example usages in Launch Pad](https://sourcegraph.com/search?q=repo:%5Egithub.com/ubclaunchpad/*+lang:html+%3Cscript+src%3D%22https://chinchilla.ubclaunchpad.com/script.js%22&patternType=literal).
+* If you need more granular control, you can use [`fathom-client`](https://github.com/derrickreimer/fathom-client) instead of the embedding the tracker script - see [example usages in Launch Pad](https://sourcegraph.com/search?q=repo:%5Egithub.com/ubclaunchpad/*+Fathom.load%28&patternType=literal).
+  * for [Vue.js](https://vuejs.org/) projects, you can use [`@ubclanchpad/vue-fathom`](https://github.com/ubclaunchpad/vue-fathom)
+  * for [Vuepress](https://vuepress.vuejs.org/) projects, you can use [`@ubclaunchpad/vuepress-plugin-fathom`](https://github.com/ubclaunchpad/vuepress-plugin-fathom)


### PR DESCRIPTION
### Related Tickets

<!-- List relevant tickets, e.g. 'Closes #<some_ticket_number>' -->

Closes #65 related: https://github.com/ubclaunchpad/ubclaunchpad.com/pull/178

### Changes

<!-- Briefly describe the changes you made -->

Adds Fathom Analytics as our recommended web analytics solution, and provides a quick guide and examples to get started.

Preview: https://deploy-preview-105--ubclaunchpad-docs.netlify.app/handbook/tools/analytics