### PR TITLE
define sidebar groups for related pages

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,8 @@ Closes #
 
 <!-- Briefly describe the changes you made -->
 
+
+
 ### Checklist
 
 * I've read the [Structuring Content](https://docs.ubclaunchpad.com/CONTRIBUTING#structuring-content) guide

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,13 @@
 ### Related Tickets
 
-<!-- List relevant tickets, e.g. 'Closes #<some_ticket_number>' -->
+<!-- List relevant tickets, e.g. 'Closes #<some_ticket_number>', or just write 'n/a' -->
 
 Closes #
 
 ### Changes
 
 <!-- Briefly describe the changes you made -->
+
+### Checklist
+
+* I've read the [Structuring Content](https://docs.ubclaunchpad.com/CONTRIBUTING#structuring-content) guide

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -68,8 +68,27 @@ module.exports = {
     ],
     searchPlaceholder: 'Search...',
 
-    // automatically generate a sidebar for each page
-    sidebar: 'auto',
+    sidebar: {
+      // generate grouped sidebars for groups of pages
+      '/handbook/onboarding/': [
+        'everyone',
+        'design',
+        'strategy',
+        'leads',
+      ],
+      '/handbook/project-management/': [
+        'scope',
+        'sprints',
+        'repositories',
+      ],
+      '/handbook/tools/': [
+        'slack',
+        'github',
+        'deployment',
+      ],
+      // automatically generate a sidebar for each page
+      '/': 'auto',
+    },
     sidebarDepth: 2,
     smoothScroll: true,
 

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -68,6 +68,7 @@ module.exports = {
     ],
     searchPlaceholder: 'Search...',
 
+    // see https://vuepress.vuejs.org/theme/default-theme-config.html#multiple-sidebars
     sidebar: {
       // generate grouped sidebars for groups of pages
       '/handbook/onboarding/': [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,33 @@ While the [Easy Way](#the-easy-way) is good for small changes, writing larger ch
 
 More details on using `git` is available in our [Git Workflow guide](./resources/git-workflow.md).
 
-## Scripts
+## Structuring Content
+
+In general:
+
+* `handbook/` should have Launch Pad-specific documentation (some of it might be generally useful, however - if so, link to it from Resources)
+* `resources/` should have general learning resources
+* Before creating a new section, look for an existing section where your new content could live instead, and create links from other relevant sections if possible.
+* Feel free to add a badge to new or updated content:
+  ```
+  <Badge type="tip" text="new"/>
+  ```
+* Images should go in a `/img` folder in the same directory.
+* Headers can *start* with emoji, but don't put emojis anywhere else in a header!
+* Use **relative links** to content within the website - this means `/handbook/file.md` instead of `https://docs.ubclaunchpad.com/..`!
+
+### Nested Folders
+
+Any folders deeper than the top-level documents (such as `handbook/`, `resources/`) should *not* have a dedicated README in its folder - instead, a "table of contents" of the directory should be placed in one of the top-level documents' READMEs. For example, the contents of `resources/project-management` are listed in `resources/README.md` and *not* `resources/project-management/README.md`.
+
+When adding a new file to a subfolder of content (for example, `handbook/tools`), make sure you:
+
+* add a link to `handbook/README.md`
+* if the subfolder has a [defined sidebar group](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/ubclaunchpad/docs%24+file:%5E%5C.vuepress/config%5C.js+sidebar&patternType=literal), add your new page to the group
+
+## Technical Details
+
+### Scripts
 
 This repo offers some `package.json` scripts to help you out:
 
@@ -48,29 +74,14 @@ npm run hooks    # installs the git commit hook that runs the linter before you 
 npm run serve    # runs the website locally
 ```
 
-## Structuring Content <Badge type="tip" text="new"/>
-
-* Any folders deeper than the top-level documents (such as `handbook/`, `resources/`) should not have a dedicated README in its folder - instead, a "table of contents" of the directory should be placed in one of the top-level documents' READMEs.
-  * For example, the contents of `resources/project-management` are listed in `resources/README.md` and *not* `resources/project-management/README.md`.
-* Before creating a new section, look for an existing section where your new content could live instead, and create links from other relevant sections if possible.
-* In general:
-  * `handbook/` should have Launch Pad-specific documentation (some of it might be generally useful, however - if so, link to it from Resources)
-  * `resources/` should have general learning resources
-* Feel free to add a badge to new or updated content:
-  ```
-  <Badge type="tip" text="new"/>
-  ```
-* Images should go in a `/img` folder in the same directory.
-* Headers can *start* with emoji, but don't put emojis anywhere else in a header!
-
-## VuePress
+### VuePress
 
 This website is based on [VuePress](https://vuepress.vuejs.org/guide/) - refer to the
 VuePress documentation for more details. VuePress takes the [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) content in this repository (all those `.md` files) and turns them into the pretty website on `docs.ubclaunchpad.com`.
 
 Most VuePress configuration lives in [`.vuepress/config.js`](./.vuepress/config.js).
 
-## Deployment
+### Deployment
 
 Deployments are handled automatically by the [Netlify](https://www.netlify.com/) - the website is managed under the "Launch Pad OSS Sponsored" team. Build and deploy options can be declared in [`netlify.toml`](./netlify.toml).
 

--- a/handbook/onboarding/design.md
+++ b/handbook/onboarding/design.md
@@ -1,4 +1,4 @@
-# 🚀 Onboarding for Design
+# 🎨 Onboarding for Design
 
 ## Checklist
 

--- a/handbook/onboarding/leads.md
+++ b/handbook/onboarding/leads.md
@@ -1,4 +1,4 @@
-# 🚀 Onboarding for Leads
+# 🎉 Onboarding for Leads
 
 Welcome to UBC Launch Pad, and congratulations (and thank you!) for joining us as a lead!
 

--- a/handbook/onboarding/strategy.md
+++ b/handbook/onboarding/strategy.md
@@ -1,4 +1,4 @@
-# 🚀 Onboarding for Strategy
+# 💼 Onboarding for Strategy
 
 Welcome to UBC Launch Pad, and congratulations (and thank you!) for joining the strategy team!
 

--- a/handbook/tools/deployment.md
+++ b/handbook/tools/deployment.md
@@ -1,4 +1,4 @@
-# Deployment
+# 🚢 Deployment
 
 For general deployment advice, see [the Deployment page in Resources](../../resources/deployment.md).
 This page specifically documents options available to Launch Pad projects.

--- a/handbook/tools/slack.md
+++ b/handbook/tools/slack.md
@@ -1,4 +1,4 @@
-# 💬 Slack Guide
+# 💬 Slack
 
 We use [Slack](https://slack.com) for team-wide communication, announcements, and project-specific coordination. The workspace can be found [here](https://ubclaunchpad.slack.com). You should receive an invite in your email to join the workspace - if you haven't, please reach out to your lead or one of the presidents for help!
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1002,9 +1002,9 @@
       }
     },
     "@vue/babel-preset-app": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-4.4.1.tgz",
-      "integrity": "sha512-VHVROEBBiW0dnuNuzlFElkncXo+zxh5Px0MZ51Th5da8UPbQodf43mnpotMnFtmCPTXAFL58tzDttu1FgrgfpQ==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-4.4.4.tgz",
+      "integrity": "sha512-9b74d/lz4GEc9zkF3C+vjgEXYqu9ITq1DimUT+IVRJDvhgnV+a3C+pQY4Kl4PZSOyqkTHM7jE6eG2K5DUwKpWg==",
       "requires": {
         "@babel/core": "^7.9.6",
         "@babel/helper-compilation-targets": "^7.9.6",
@@ -1120,17 +1120,17 @@
       }
     },
     "@vuepress/core": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-1.5.1.tgz",
-      "integrity": "sha512-gLogkq6Mm8/y7SuywNNE2ny2idMAoBUnRV40TpYK1pOAjQKRlbh3C1fDck+N/nUubB7zKkZUt7uBVqzSRGk9/g==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-DaRLzShuT116mu6ObsgfFXk+BX2c0W1Zp+BcIg1W5HrRhMZFnMvncdx9iiIjJhXdhVcaBYrVa3Y2624V113TBA==",
       "requires": {
         "@babel/core": "^7.8.4",
         "@vue/babel-preset-app": "^4.1.2",
-        "@vuepress/markdown": "1.5.1",
-        "@vuepress/markdown-loader": "1.5.1",
-        "@vuepress/plugin-last-updated": "1.5.1",
-        "@vuepress/plugin-register-components": "1.5.1",
-        "@vuepress/shared-utils": "1.5.1",
+        "@vuepress/markdown": "1.5.2",
+        "@vuepress/markdown-loader": "1.5.2",
+        "@vuepress/plugin-last-updated": "1.5.2",
+        "@vuepress/plugin-register-components": "1.5.2",
+        "@vuepress/shared-utils": "1.5.2",
         "autoprefixer": "^9.5.1",
         "babel-loader": "^8.0.4",
         "cache-loader": "^3.0.0",
@@ -1165,11 +1165,11 @@
       }
     },
     "@vuepress/markdown": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-1.5.1.tgz",
-      "integrity": "sha512-GzlSa2stbmcnAIgdQISXzDW6qlXONp0wxdB5OFOJe6tBHW1JcSiXFk6A9bcQuYKoF+wyAZyrLExpM8FVp0qpug==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-1.5.2.tgz",
+      "integrity": "sha512-736fVRZh4x3QOORWhhz2IzCdrOKOnGL7KpWQ59Y+lg7SYNETRvxGxGXTFGrfd+hR9GugThj952BaWWpUCrO7fw==",
       "requires": {
-        "@vuepress/shared-utils": "1.5.1",
+        "@vuepress/shared-utils": "1.5.2",
         "markdown-it": "^8.4.1",
         "markdown-it-anchor": "^5.0.2",
         "markdown-it-chain": "^1.3.0",
@@ -1193,69 +1193,69 @@
       }
     },
     "@vuepress/markdown-loader": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@vuepress/markdown-loader/-/markdown-loader-1.5.1.tgz",
-      "integrity": "sha512-yITErIhfzjNBV4KC4dALGDoe9nIF29YQcIC0UbtNtV2zlkUERkRkP+AowT3G1WMBYzY3XhtoCZqXtxxuSCDILQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/markdown-loader/-/markdown-loader-1.5.2.tgz",
+      "integrity": "sha512-ZRW/sQk5EK1yNKjWFNdfLmdlQXgT8GUBrnWQDV6FRwh5r+NmSJsgEYISmewGgGGzlUY+GUJKiUjGhe7itztB2Q==",
       "requires": {
-        "@vuepress/markdown": "1.5.1",
+        "@vuepress/markdown": "1.5.2",
         "loader-utils": "^1.1.0",
         "lru-cache": "^5.1.1"
       }
     },
     "@vuepress/plugin-active-header-links": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-active-header-links/-/plugin-active-header-links-1.5.1.tgz",
-      "integrity": "sha512-GGqmlJlIJ3NEkAi2Gzob6CemDL5o0cv4TRLvWzjW43H0Pj1idoOi0mbKXtWAIZ6QicrZupeJUMhy49qyipvSWQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-active-header-links/-/plugin-active-header-links-1.5.2.tgz",
+      "integrity": "sha512-bZP/0jpouVSvMypixx2/I7kxWFUV4HfwLNx7UxbtuDrykQzXnA2cz6yTra8Y1ZoXACbRp6TIqGlWpCUafBzyww==",
       "requires": {
         "lodash.debounce": "^4.0.8"
       }
     },
     "@vuepress/plugin-back-to-top": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-back-to-top/-/plugin-back-to-top-1.5.1.tgz",
-      "integrity": "sha512-YP1h+oLhhjtUhoyg7418D+Nazdczqo36gevJwV1Zgtqs8PJ970aa8+UrSI5+uN/bRVRn0FUSsgRLF3jIM8wnwg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-back-to-top/-/plugin-back-to-top-1.5.2.tgz",
+      "integrity": "sha512-eLieTccUQ8XdIqQXWyp0bftfud9js1idHFFyxuhHWSYAco/vTp7wLz7JdFqr8GnFye9y88B1y34iLnbZLiBlmA==",
       "requires": {
         "lodash.debounce": "^4.0.8"
       }
     },
     "@vuepress/plugin-google-analytics": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-google-analytics/-/plugin-google-analytics-1.5.1.tgz",
-      "integrity": "sha512-mbOUu07aXEVbuzlcheZkVzLpnveKciQ1iuYXuWa26W141kKwdIFvd4JQV7emWpOG8KMMI9/GL3Lej7KRTAa41w=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-google-analytics/-/plugin-google-analytics-1.5.2.tgz",
+      "integrity": "sha512-MrM/Zs0VbOclL0xKXS/Gi017Kl42oiWHUDr2Uz5VCQjqGB1FyAsQdGLtloE1Y6rtTuDXektsss9Bx9uX0f1amw=="
     },
     "@vuepress/plugin-last-updated": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-last-updated/-/plugin-last-updated-1.5.1.tgz",
-      "integrity": "sha512-uG9P88gJ7KxmMDcTCEHbT248rJ0fZABeHxvyXodUAzSG0bDdqXjw4p34PdkzlWnHHLDiYKBIHIcEYSvKmOiRPQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-last-updated/-/plugin-last-updated-1.5.2.tgz",
+      "integrity": "sha512-wTq1reNSpGTSPJcnUHFfg+qpZBg88yXv3fZNWnEGSdiuUnbF4bFMTUr9tSaWHzMgtajvzY2B8VnTmrhy2ABfsA==",
       "requires": {
         "cross-spawn": "^6.0.5"
       }
     },
     "@vuepress/plugin-nprogress": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-1.5.1.tgz",
-      "integrity": "sha512-BMoJL9Xc+XKoiVe7pSZntuVkt06u8i594J3Q4eEFkmrSRj8D+n9YFFjdRWTfae2haPMtMAvwpVeohAQ6ii61LA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-1.5.2.tgz",
+      "integrity": "sha512-PtiV5u9hHZJNPmyKs7s++f4GCJTuvPP25aIASi06vKACr/+Ier5XC7PvOwUvS1LbG6HAGRbQpokmeP1aVbrI6w==",
       "requires": {
         "nprogress": "^0.2.0"
       }
     },
     "@vuepress/plugin-register-components": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-register-components/-/plugin-register-components-1.5.1.tgz",
-      "integrity": "sha512-pnovxJepFIQ8mx+uXg62OZ9KoFE1aOIBKxOmmtI5g9Qurx2NTVv5AWUtoi76xYbCxBpl313ffcCyvxMUfXPsrQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-register-components/-/plugin-register-components-1.5.2.tgz",
+      "integrity": "sha512-e0GYZG6KXa7axy8GO9sNtLaZNW+lXlidWCURg61/gfKISG5yzKr71n75j5V7pyEJ/idAV/sAakunp7+6nsShDg==",
       "requires": {
-        "@vuepress/shared-utils": "1.5.1"
+        "@vuepress/shared-utils": "1.5.2"
       }
     },
     "@vuepress/plugin-search": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-search/-/plugin-search-1.5.1.tgz",
-      "integrity": "sha512-JyYrTzDDZs6ANZgp7+DnuRTm3OB1LgrxUJriD5qLb7NXEDwWvJnf7noFxnp7j+yaMogCZN1IloTU0PLSLqub9A=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-search/-/plugin-search-1.5.2.tgz",
+      "integrity": "sha512-/n0W7lQhBCj7vrIhU6VL8ZlUnWBru83W4w0gGNxzXDzZ1AMRJRnQDamBjKAWNd+WMYz8LA2LbJy1rCCds1Mu2Q=="
     },
     "@vuepress/shared-utils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@vuepress/shared-utils/-/shared-utils-1.5.1.tgz",
-      "integrity": "sha512-rktTYlKa4vla6GlUZZmIiIW6Dfl+YbfcgGvkWE5A7MiIqEmJKnoqKOxJOHLPbnD+T5Ssfu71bj4FVXCG89DUmA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/shared-utils/-/shared-utils-1.5.2.tgz",
+      "integrity": "sha512-msDE6Mpof9JDVZQDHYUbsKmQm4aT/CUlUnItlORF+0J4xrIzv96dldJb8pvloDNUjyvB3DXeDJrV4V1XzpwsIA==",
       "requires": {
         "chalk": "^2.3.2",
         "diacritics": "^1.3.0",
@@ -1276,13 +1276,13 @@
       }
     },
     "@vuepress/theme-default": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@vuepress/theme-default/-/theme-default-1.5.1.tgz",
-      "integrity": "sha512-CojJNniskrFWE/LQg7WE+4SYg7Q8xMChqXj74C4/475kCOd9dPHVeCkuvmjIpZ7NJ2m96aNlG1TvDnOTuhLCCQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/theme-default/-/theme-default-1.5.2.tgz",
+      "integrity": "sha512-sO44ExAoO+pNO5qJJvlFin1vaBjxYkTO5oiBu53sYoInAoN3liG1uraMpyaGmhdmzCSlGQpqH+ojtnISTmfAcg==",
       "requires": {
-        "@vuepress/plugin-active-header-links": "1.5.1",
-        "@vuepress/plugin-nprogress": "1.5.1",
-        "@vuepress/plugin-search": "1.5.1",
+        "@vuepress/plugin-active-header-links": "1.5.2",
+        "@vuepress/plugin-nprogress": "1.5.2",
+        "@vuepress/plugin-search": "1.5.2",
         "docsearch.js": "^2.5.2",
         "lodash": "^4.17.15",
         "stylus": "^0.54.5",
@@ -2396,9 +2396,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001081",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001081.tgz",
-      "integrity": "sha512-iZdh3lu09jsUtLE6Bp8NAbJskco4Y3UDtkR3GTCJGsbMowBU5IWDFF79sV2ws7lSqTzWyKazxam2thasHymENQ=="
+      "version": "1.0.30001083",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001083.tgz",
+      "integrity": "sha512-CnYJ27awX4h7yj5glfK7r1TOI13LBytpLzEgfj0s4mY75/F8pnQcYjL+oVpmS38FB59+vU0gscQ9D8tc+lIXvA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -2709,9 +2709,9 @@
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
     },
     "consola": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.12.2.tgz",
-      "integrity": "sha512-c9mzemrAk57s3UIjepn8KKkuEH5fauMdot5kFSJUnqHcnApVS9Db8Rbv5AZ1Iz6lXzaGe9z1crQXhJtGX4h/Og=="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.13.0.tgz",
+      "integrity": "sha512-Jw+8qpL0yrpfqH9m90fWoDRQyn8TYU6Aegpl4UofoP81VYvQLoOWMpFw2vQ3U/cyLRRzTc/CyNC6YYVzZFU8Eg=="
     },
     "console-browserify": {
       "version": "1.2.0",
@@ -3544,9 +3544,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.465",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.465.tgz",
-      "integrity": "sha512-K/lUeT3NLAsJ5SHRDhK3/zd0tw7OUllYD8w+fTOXm6ljCPsp2qq+vMzxpLo8u1M27ZjZAjRbsA6rirvne2nAMQ=="
+      "version": "1.3.473",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.473.tgz",
+      "integrity": "sha512-smevlzzMNz3vMz6OLeeCq5HRWEj2AcgccNPYnAx4Usx0IOciq9DU36RJcICcS09hXoY7t7deRfVYKD14IrGb9A=="
     },
     "elliptic": {
       "version": "6.5.2",
@@ -3649,21 +3649,21 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -8213,26 +8213,6 @@
         "es-abstract": "^1.17.5"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimstart": "^1.0.0"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimend": "^1.0.0"
-      }
-    },
     "string.prototype.trimstart": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
@@ -9020,9 +9000,9 @@
       }
     },
     "vue-router": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.3.2.tgz",
-      "integrity": "sha512-5sEbcfb7MW8mY8lbUVbF4kgcipGXsagkM/X+pb6n0MhjP+RorWIUTPAPSqgPaiPOxVCXgAItBl8Vwz8vq78faA=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.3.4.tgz",
+      "integrity": "sha512-SdKRBeoXUjaZ9R/8AyxsdTqkOfMcI5tWxPZOUX5Ie1BTL5rPSZ0O++pbiZCeYeythiZIdLEfkDiQPKIaWk5hDg=="
     },
     "vue-server-renderer": {
       "version": "2.6.11",
@@ -9092,12 +9072,12 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
     },
     "vuepress": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/vuepress/-/vuepress-1.5.1.tgz",
-      "integrity": "sha512-UB5YHwcS1t0XVPfMN4pcKanH2Wb9XvhRNJMGt4O9wiUauwlgC6cwnwhatR3AmsbiwybQYgiOSj+CJKuhjYgAeQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/vuepress/-/vuepress-1.5.2.tgz",
+      "integrity": "sha512-buscwFfIqvCcUAaRdbBWENmCSBZzr510fch1BhQZwVaQy28mF8H6Mvb+UDdwHQ7jon0d9qauXs9M0k4XHIWviw==",
       "requires": {
-        "@vuepress/core": "1.5.1",
-        "@vuepress/theme-default": "1.5.1",
+        "@vuepress/core": "1.5.2",
+        "@vuepress/theme-default": "1.5.2",
         "cac": "^6.5.6",
         "envinfo": "^7.2.0",
         "opencollective-postinstall": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   },
   "dependencies": {
     "@ubclaunchpad/vuepress-plugin-fathom": "~1.2.1",
-    "@vuepress/plugin-back-to-top": "~1.5.1",
-    "@vuepress/plugin-google-analytics": "~1.5.1",
+    "@vuepress/plugin-back-to-top": "~1.5.2",
+    "@vuepress/plugin-google-analytics": "~1.5.2",
     "emoji-regex": "~9.0.0",
     "markdownlint": "~0.20.3",
     "markdownlint-cli": "~0.23.1",
-    "vuepress": "~1.5.1",
+    "vuepress": "~1.5.2",
     "vuepress-plugin-clean-urls": "~1.1.1",
     "vuepress-plugin-fulltext-search": "https://github.com/bobheadlabs/vuepress-plugin-fulltext-search.git",
     "vuepress-theme-yuu": "~2.3.0"


### PR DESCRIPTION
### Related Tickets

<!-- List relevant tickets, e.g. 'Closes #<some_ticket_number>' -->

n/a

### Changes

<!-- Briefly describe the changes you made -->

Finally possible now that my PR at https://github.com/vuejs/vuepress/pull/2380 is merged 😅 

This PR defines sidebars for related groups of pages (ie `/handbook/onboarding/...`). Unfortunately must be manually defined.

Hopefully, this helps with navigation - examples:

<img width="275" alt="image" src="https://user-images.githubusercontent.com/23356519/84605842-2f1d4000-aed3-11ea-9426-7c26b032a7e2.png">  <img width="293" alt="image" src="https://user-images.githubusercontent.com/23356519/84605848-393f3e80-aed3-11ea-9e08-accf7d93021e.png">

