### PR TITLE
Adds heroku documentation

### DIFF
--- a/handbook/tools/deployment.md
+++ b/handbook/tools/deployment.md
@@ -29,6 +29,10 @@ We recommend using [Netlify's file-based configuration](https://docs.netlify.com
 
 ### Heroku
 
-[Heroku](https://www.heroku.com/what) is a cloud platform that allows you deploy a variety of applications. Heroku can be used as a [remote target](https://devcenter.heroku.com/articles/git), or you can have it [track a branch on a Github repository](https://devcenter.heroku.com/articles/github-integration) and auto-deploy whenever that branch is updated. You can find more information on [Heroku's documentation](https://devcenter.heroku.com/).
+[Heroku](/resources/deployment.md#heroku) is also a good option that UBC Launch Pad has used in the past. It is a cheap alternative to deploy simple applications. Heroku has a free option that is useful for demos or for applications that do not require to stay up all the time.
 
-Heroku is typically a good option to quickly bootstrap applications, it also offers a [free option](https://www.heroku.com/free) with some limitations.
+[`ubclaunchpad/sync`](https://github.com/ubclaunchpad/sync) uses Heroku to deploy it's backend.
+
+::: tip
+As a student, you have access to [Github's student developer pack](https://education.github.com/pack), which includes a free Heroku [hobby dyno](https://devcenter.heroku.com/articles/dyno-types). The hobby dyno is a great deployment option for small scale applications, and unlike the free dyno, the application does not go to sleep.
+:::

--- a/handbook/tools/deployment.md
+++ b/handbook/tools/deployment.md
@@ -29,6 +29,6 @@ We recommend using [Netlify's file-based configuration](https://docs.netlify.com
 
 ### Heroku
 
-:: warning
-TODO [#110](https://github.com/ubclaunchpad/docs/issues/110)
-::
+[Heroku](https://www.heroku.com/what) is a cloud platform that allows you deploy a variety of applications. Heroku can be used as a [remote target](https://devcenter.heroku.com/articles/git), or you can have it [track a branch on a Github repository](https://devcenter.heroku.com/articles/github-integration) and auto-deploy whenever that branch is updated. You can find more information on [Heroku's documentation](https://devcenter.heroku.com/).
+
+Heroku is typically a good option to quickly bootstrap applications, it also offers a [free option](https://www.heroku.com/free) with some limitations.

--- a/handbook/tools/deployment.md
+++ b/handbook/tools/deployment.md
@@ -31,7 +31,7 @@ We recommend using [Netlify's file-based configuration](https://docs.netlify.com
 
 [Heroku](/resources/deployment.md#heroku) is also a good option that UBC Launch Pad has used in the past. It is a cheap alternative to deploy simple applications. Heroku has a free option that is useful for demos or for applications that do not require to stay up all the time.
 
-[`ubclaunchpad/sync`](https://github.com/ubclaunchpad/sync) uses Heroku to deploy it's backend.
+[`ubclaunchpad/sync`](https://github.com/ubclaunchpad/sync) uses Heroku to deploy its backend.
 
 ::: tip
 As a student, you have access to [Github's student developer pack](https://education.github.com/pack), which includes a free Heroku [hobby dyno](https://devcenter.heroku.com/articles/dyno-types). The hobby dyno is a great deployment option for small scale applications, and unlike the free dyno, the application does not go to sleep.

--- a/resources/deployment.md
+++ b/resources/deployment.md
@@ -20,3 +20,9 @@ that lets you easily provision a remote for deployment.
 
 Feel free to swing by [#ask-inertia](https://ubclaunchpad.slack.com/messages/CJVF27QUS/)
 if you have any questions!
+
+## Heroku
+
+[Heroku](https://www.heroku.com/what) is a cloud platform that allows you deploy a variety of applications. Heroku can be used as a [remote target](https://devcenter.heroku.com/articles/git), or you can have it [track a branch on a Github repository](https://devcenter.heroku.com/articles/github-integration) and auto-deploy whenever that branch is updated. You can find more information on [Heroku's documentation](https://devcenter.heroku.com/).
+
+Heroku is typically a good option to quickly bootstrap applications, it also offers a [free option](https://www.heroku.com/free) with some limitations.


### PR DESCRIPTION
fixes #110 

### Changes

I took it because... aaah saw it and was like "This should be quick"

Adds simple Heroku documentation. Mostly just references the Heroku docs. The duplication of deployment documentation feels off, but I guess one is for general documentation and another for Launch Pad specific options? Still not sure why both need to exist so opinions are welcome! (thinking best thing to do maybe is just referencing the `handbook` one from the `resources` one)



### Checklist

* I've read the [Structuring Content](https://docs.ubclaunchpad.com/CONTRIBUTING#structuring-content) guide
* I've read up on our [Pull Request checks](https://docs.ubclaunchpad.com/CONTRIBUTING#checks)
