### PR TITLE
add tips linking to google recruitment forms

### DIFF
--- a/handbook/recruitment/designer.md
+++ b/handbook/recruitment/designer.md
@@ -7,8 +7,10 @@ search: false
 
 > UBC Launch Pad 2020 Team
 
-::: warning We are not currently accepting applications for this role.
-Sign up for [our newsletter](https://ubclaunchpad.com/newsletter) to get updates!
+::: tip
+We are currently accepting applications for this role!
+
+To apply, fill out [this Google Form](https://forms.gle/4u6qeKqrzav2MzwK7) before 11:59 PM on August 21, 2020.
 :::
 
 ## Summary

--- a/handbook/recruitment/developer.md
+++ b/handbook/recruitment/developer.md
@@ -7,8 +7,10 @@ search: false
 
 > UBC Launch Pad 2020 Team
 
-:::  warning We are not currently accepting applications for this role.
-Sign up for [our newsletter](https://ubclaunchpad.com/newsletter) to get updates!
+::: tip
+We are currently accepting applications for this role!
+
+To apply, fill out [this Google Form](https://forms.gle/p3U3WuiNH7pafFgp7) before 11:59 PM on August 21, 2020.
 :::
 
 ## Summary


### PR DESCRIPTION
### Related Tickets
n/a

### Changes

Previously, these pages had a warning saying that we are not accepting applications. However, with the upcoming recruitment campaign, we want to say that we are now accepting applications and we want to link users directly to the application form.

### Checklist

* I've read the [Structuring Content](https://docs.ubclaunchpad.com/CONTRIBUTING#structuring-content) guide
* I've read up on our [Pull Request checks](https://docs.ubclaunchpad.com/CONTRIBUTING#checks)
