### PR TITLE
consolidate google drive info in drive.md

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -90,6 +90,7 @@ module.exports = {
       '/handbook/tools/': [
         'slack',
         'github',
+        'drive',
         'deployment',
         'analytics',
         'social-media',

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -30,6 +30,7 @@ We use a variety of technology and tools at Launch Pad - these sections help you
 
 * [**Slack**](./tools/slack.md): Best practices, channels, bots, and general information about our Slack workspace! Slack is where most Launch Pad discussions and announcements happen.
 * [**GitHub**](./tools/github.md): Guidance on getting started with our GitHub organization! GitHub is where we host, document, and manage the code in all our projects.
+* [**Google Drive**](./tools/drive.md): How to use Launch Pad's shared Google Drive folders.
 * [**Deployment**](./tools/deployment.md): Launch Pad's recommendations regarding deployment and getting your project out to the world.
 * [**Analytics**](./tools/analytics.md): Launch Pad's recommendations regarding setting up analytics to see how users interact with your projects.
 * [**Social Media**](./tools/social-media.md): Documentation about our social media accounts and how to use them to help showcase our work!

--- a/handbook/onboarding/leads.md
+++ b/handbook/onboarding/leads.md
@@ -35,26 +35,7 @@ Make sure that you are **watching** all relevant repositories so that you don't 
 
 Make sure all leads are given "editor" access to the [shared Launch Pad folder](https://drive.google.com/drive/folders/1u-U3w0V0MaLQrWtDdw_8n15V2lO-6gXo), which is owned by the `team@ubclaunchpad.com` account (more details are in the [Exec repository](https://github.com/ubclaunchpad/exec)).
 
-Within the shared Launch Pad folder, try to maintain the following structure:
-
-* [Projects](https://drive.google.com/drive/u/0/folders/18piFDBdAUuZAOf9xOgpf2_HBUuVNae0S) - folders for project teams
-  * Note that everyone should be granted access to this folder (part of [Onboarding for Everyone](../onboarding/everyone.md))
-  * Each tech lead should create a folder for their project inside a year subfolder ("Projects YYYY") of this folder
-  * Inside each project folder, each lead should create a document for meeting notes. All their project meetings should go in this document. See [Sprint Planning](../project-management/sprints.md) for more details.
-* [Strategy](https://drive.google.com/drive/u/0/folders/0BwdNv1PZjDeXMkc1eDVNY1ZHT00) - see [Onboarding for Strategy](./strategy.md)
-* [Design](https://drive.google.com/drive/u/0/folders/1Zfe25r3D77hGdyMkj0tlxHNa-r7fAq1d) - see [Onboarding for Design](./design.md)
-* [Leads](https://drive.google.com/drive/u/0/folders/1hgPcUC_DrFMmzZ04pBSlZFig4v9AbTuv) - that's for us!
-  * Leads should create a document for meeting notes titled "Leads: Meeting Notes YYYY". All leads meetings should go in this document.
-* [Exec](https://drive.google.com/drive/u/0/folders/10b_2H5EhPpJtdgNi7QizRhWC9Qtivr8L) - for the presidents
-  * Presidents should create a document for meeting notes titled "Exec: Meeting Notes YYYY". All exec meetings should go in this document.
-
-::: warning
-In general, assume pretty liberal with access to folders in Google Drive (since it is hard to keep track of access over time, especially for individual documents, and for ease of use we generally share entire folders with everyone).
-
-Sensitive information (such as contact details for sponsors) should be tracked in one of our [private GitHub repositories](#github-teams) and distributed as required (for example, by linking to specific issues from Drive documents).
-
-Similarly, **do not add credentials (usernames, passwords) in Google Drive**. Instead, get them added to the private [Exec repository](https://github.com/ubclaunchpad/exec/blob/master/assets.md) and provide the credentials to those who need it as required.
-:::
+Learn more about managing these folders in the [Google Drive documentation](/handbook/tools/drive.md).
 
 ### Email and Accounts
 

--- a/handbook/tools/drive.md
+++ b/handbook/tools/drive.md
@@ -1,0 +1,31 @@
+# 🗂 Google Drive
+
+At Launch Pad, we leverage [Google Drive](https://drive.google.com/) for most of our miscellaneous document-sharing needs. Permanent documentation about processes, however, should be committed to [GitHub](/handbook/tools/github.md) - for example, in the [`docs.ubclaunchpad.com` repository](https://github.com/ubclaunchpad/docs).
+
+Launch Pad Google Drive folders are managed by the [`team@ubclaunchpad.com` GSuite account](email.md). Credentials for the account are available in the [Exec repository](https://github.com/ubclaunchpad/exec).
+
+::: warning Sensitive information
+In general, assume pretty liberal with access to folders in Google Drive, since it is hard to keep track of access over time, especially for individual documents, and for ease of use we generally share entire folders with everyone.
+
+Because of this, sensitive information (such as contact details for sponsors) should be tracked in one of our [private GitHub repositories](/handbook/onboarding/leads.md#github-teams) and distributed as required (for example, by linking to specific issues from Drive documents).
+
+Similarly, **do not add credentials (usernames, passwords) in Google Drive**. Instead, get them added to the private [Exec repository](https://github.com/ubclaunchpad/exec/blob/master/assets.md) and provide the credentials to those who need it as required.
+:::
+
+## Folders
+
+A list of shared Drive folders used at Launch Pad can be found in the "Quick Links" dropdown in the top right corner of the [`docs.ubclaunchpad.com`](https://docs.ubclaunchpad.com/) website. These folders are defined in [the site configuration](https://sourcegraph.com/github.com/ubclaunchpad/docs/-/blob/.vuepress/config.js#L37-45). Please refer to the [onboarding documentation](/handbook/onboarding/everyone.md) to see which folders should be shared with you.
+
+All folders should be a subfolder of the [shared Launch Pad folder](https://drive.google.com/drive/folders/1u-U3w0V0MaLQrWtDdw_8n15V2lO-6gXo) for easier access management. Within the shared Launch Pad folder, we try to maintain the following structure:
+
+* [Projects](https://drive.google.com/drive/u/0/folders/18piFDBdAUuZAOf9xOgpf2_HBUuVNae0S) - folders for project teams
+  * Note that everyone should be granted access to this folder (part of [Onboarding for Everyone](/handbook/onboarding/everyone.md))
+  * Each tech lead should create a folder for their project inside a year subfolder ("Projects YYYY") of this folder
+  * Inside each project folder, each lead should create a document for meeting notes. All their project meetings should go in this document. See [Sprint Planning](/handbook/project-management/sprints.md) for more details.
+* [Strategy](https://drive.google.com/drive/u/0/folders/0BwdNv1PZjDeXMkc1eDVNY1ZHT00) - see [Onboarding for Strategy](/handbook/onboarding/strategy.md)
+* [Design](https://drive.google.com/drive/u/0/folders/1Zfe25r3D77hGdyMkj0tlxHNa-r7fAq1d) - see [Onboarding for Design](/handbook/onboarding//design.md)
+* [Leads](https://drive.google.com/drive/u/0/folders/1hgPcUC_DrFMmzZ04pBSlZFig4v9AbTuv) - for the [leads](/handbook/onboarding/leads.md)
+  * Leads should create a document for meeting notes titled "Leads: Meeting Notes YYYY". All leads meetings should go in this document.
+  * Spreadsheets and Google Forms used for [recruitment](/handbook/recruitment/overview.md) are also kept in this folder.
+* [Exec](https://drive.google.com/drive/u/0/folders/10b_2H5EhPpJtdgNi7QizRhWC9Qtivr8L) - for the co-presidents
+  * Presidents should create a document for meeting notes titled "Exec: Meeting Notes YYYY". All exec meetings should go in this document.


### PR DESCRIPTION
### Related Tickets

<!-- List relevant tickets, e.g. 'Closes #<some_ticket_number>', or just write 'n/a' -->

n/a

### Changes

<!-- Briefly describe the changes you made -->

I'm working on documenting our recruitment process, and since we leverage Drive heavily for this, this PR sets up a page to consolidate this information

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/23356519/91656390-f44aa180-eaea-11ea-8d43-5f5d17e5f0db.png">


### Checklist

* I've read the [Structuring Content](https://docs.ubclaunchpad.com/CONTRIBUTING#structuring-content) guide
* I've read up on our [Pull Request checks](https://docs.ubclaunchpad.com/CONTRIBUTING#checks)
