### PR TITLE
kickoff retrospective: icebreaker and ideation changes, risky ideas advice

### DIFF
--- a/handbook/project-management/scope.md
+++ b/handbook/project-management/scope.md
@@ -27,6 +27,8 @@ We call the *core feature* and this set of "requirements" the **Minimum Viable P
 
 ### Ideation
 
+At Launch Pad, ideation will often happen at [kickoff events](/handbook/strategy/recurring-processes.md#kickoff-event).
+
 To help narrow down a *core feature*, start with a *theme*, which could be something like "productivity and tasks scheduling" or "Launch Pad internal tooling". From here, try to ask questions like the following to drive discussions:
 
 * What pain points do you or certain demographics face regarding this *theme*?
@@ -37,11 +39,10 @@ During discussions, keep the following in mind as well:
 
 * Go around the group to engage as many people as possible.
 * Be encouraging and positive, even if you think the ideas is not very good.
-* Instead of rejecting an idea or feature, you can discuss what kind of problem the idea is trying to tackle and suggest another potential approach, or discuss similar problems instead.
+* Instead of rejecting an idea or feature, you can discuss what kind of problem the idea is trying to tackle and suggest another potential approach, or discuss similar problems instead. Also keep in mind that there are some ideas that have historically fared poorly in Launch Pad teams - see our [risky ideas list](#risky-ideas).
+* If a single idea or person is dominating the conversation, be sure to take to time to allow other ideas to be discussed or other members to have their thoughts heard!
 
 **Avoid talking about technical details**, unless it is critical to your ideas and core features - for example, an idea that will require mobile features will likely have to be a mobile application. Be wary of having a technology you want to *really* want to use and trying to apply it to every problem you see.
-
-At Launch Pad, ideation will often happen at [kickoff events](/handbook/strategy/recurring-processes.md#kickoff-event).
 
 ## Project Timeline
 
@@ -110,3 +111,13 @@ These risks should be identified as soon as possible and tackled step by step. F
 * If you have a dependency on a third-party data source, **contact or research the third party as soon as possible** and verify the data is available, adequately formatted, etc. before you decide for sure to use it.
 
 You can also manage risk with clearly-defined tasks that encapsulates small units of work - this helps prevent difficult, long-running tasks from ballooning into a huge amount of work that bogs down your project's progress. See [Sprint Planning: Tasks](./sprints.md#tasks) for more details on how to define tasks!
+
+### Risky Ideas
+
+Some types of ideas have traditionally fared poorly at Launch Pad:
+
+* "Social network"-type projects: these frequently rely heavily on user-generated content (or just having lots of users), which often leads to unsatisfying results. Accounts, social graphs (friends, connections, interactions), and so on are often tedious and harder to implement than you might expect.
+* Projects requiring deep domain expertise: this includes projects *centered around* medical/legal/machine-learning/etc topics. Most Launch Pad teams will spend a lot of time figuring out the basics of writing software collaboratively, so it is difficult to catch the team up with the expertise required to, for example, develop a model from scratch. If the idea only requires these things tangentially - for example, if a machine learning model exists for your use case already - that should be fine!
+* Projects leverating data that is not available through supported APIs: these projects will typically involve intensive scraping of websites. Figuring out how to scrape modern websites can be a very tedious endeavour, and can be a huge time sink. Scrapers also tend to be prone to breakage when the target website changes, making them difficult to maintain.
+
+However, if your team is aware of the risks and are confident you want to move forward with ideas that fall into these categories, feel free to go for it!

--- a/handbook/strategy/recurring-processes.md
+++ b/handbook/strategy/recurring-processes.md
@@ -24,7 +24,7 @@ Each school year starts with a kickoff event where new members are introduced to
 
 ### Schedule
 
-This schedule might vary year to year, but kickoff events will generally follow this format.
+This schedule might vary year to year, but kickoff events will generally follow this format. Because a *lot* happens at our kickoff events, particularly project ideation, these have traditionally been all-day events. The current format is already condensed, due to remote requirements.
 
 | Time | Activity
 | ---- | --------
@@ -33,11 +33,12 @@ This schedule might vary year to year, but kickoff events will generally follow 
 | 15m  | [Icebreaker](#icebreakers): Round 2
 | 15m  | Break
 | 10m  | Presentation: ["Project Ideation"](#project-ideation)
-| 15m  | Ideation: Round 1
-| 5m   | Break and ideas updates
-| 15m  | Ideation: Round 2
-| 5m   | Break and ideas updates
-| 15m  | Ideation: Round 3
+| 10m  | Ideation: Round 1 (short)
+| 10m  | Ideation: Round 2 (short)
+| 10m  | Ideation: Round 3 (short)
+| 10m  | Break and ideas updates
+| 15m  | Ideation: Round 4 (long)
+| 15m  | Ideation: Round 5 (long)
 | 15m  | Conclusion
 
 ### Icebreakers
@@ -58,9 +59,10 @@ In general, the process is as follows:
 
 1. Prior to kickoff, we will ask for some "core feature" submissions via Google Forms from the entire club
 2. Leads will review the submissions and consolidate them into "themes", with each lead adopting one idea that they are interested in working on. These will act as topics for discussion groups that will become Launch Pad teams.
-3. During kickoff, the "themes" will be presented to the club, and we will form discussion groups based on interest to try and refine each "theme" back down into an "idea", and then a "core feature". Discussions will take place over several iterations.
-   * At each iteration, leads will provide updates on where each "idea" is going. In between iterations, members will be able to move between groups based on what they might be interested in. Learn more about this process in our [Project Scope guide](/handbook/project-management/scope.md#ideation).
-   * If a group arrives at a seemingly certain *core feature* in an early iteration, either try and dive deeper into your core feature to make sure that it is solid or explore different takes on your theme.
+3. During kickoff, the "themes" will be presented to the club, and we will form discussion groups based on interest to try and refine each "theme" back down into an "idea", and then a "core feature" - learn more about this process in our [Project Scope guide](/handbook/project-management/scope.md#ideation). Discussions will take place over several iterations, between which members are encouraged to switch groups.
+   * For the **first 3 shorter rounds**, members will be *required* to switch to different groups. The goal of these rounds is to brainstorm and accumulate potential directions.
+   * After the first 3 rounds, leads will provide updates on where each group is going.
+   * For the **last 2 longer rounds**, leads will start focusing on narrowing down ideas and prioritizing more feasible directions. Members will still be able to move in between these rounds.
 4. After the last round of discussions, we will ask everyone for their group preferences and try to assign everyone to a team such that the teams are reasonably balanced in size and experience.
 
 Note that the goal of ideation is to simply define a ["core feature"](/handbook/project-management/scope.md#core-feature-and-the-mvp) which will then be specc'd out into a minimum viable product (MVP) during the following week. This is when implementation and design details can be decided, so don't worry too much about that during ideation!

--- a/handbook/strategy/recurring-processes.md
+++ b/handbook/strategy/recurring-processes.md
@@ -42,11 +42,13 @@ This schedule might vary year to year, but kickoff events will generally follow 
 
 ### Icebreakers
 
-Icebreakers are intended to help everyone familiarize themselves with some members of Launch Pad. Members are assigned to groups in each icebreaker round, where everyone works together on an activity. We have done various activities for icebreakers in the past, but our current activity is a discussion prompt:
+Icebreakers are intended to help everyone familiarize themselves with some members of Launch Pad. Members are assigned to groups in each icebreaker round, where everyone works together on an activity. We have done various activities for icebreakers in the past, but one such activity is a discussion prompt:
 
 > Find up to three things everyone in your group has in common (for example, syllables in names or sock colour) and one dimension where you are the most diverse (for example, nationality or major).
 
-The goal of this activity is for groups to collaborate by coming up with a strategy for finding commonalities and differences, while getting to know each other better!
+The lead in the group should start by encouraging each member to make a self-introduction. The goal of this activity is for groups to collaborate by coming up with a strategy for finding commonalities and differences, while getting to know each other better!
+
+[docs#186](https://github.com/ubclaunchpad/docs/issues/186) tracks possible improvements we could make to our icebreakers.
 
 ### Project Ideation
 


### PR DESCRIPTION
### Related Tickets

<!-- List relevant tickets, e.g. 'Closes #<some_ticket_number>', or just write 'n/a' -->

n/a

### Changes

<!-- Briefly describe the changes you made -->

Applies some changes from our kickoff retrospective today:

* Tweaks to icebreaker format (mostly just a link to https://github.com/ubclaunchpad/docs/issues/186 though)
* Changes to ideation format - added recommendation for more rounds
* Response to feedback that kickoff was unexpectedly long with warning that these things are long
* Add advice about "risky ideas", to help leads steer discussions
* Add note in ideation discussion about ideas/people dominating the conversation

### Checklist

* I've read the [Structuring Content](https://docs.ubclaunchpad.com/CONTRIBUTING#structuring-content) guide
* I've read up on our [Pull Request checks](https://docs.ubclaunchpad.com/CONTRIBUTING#checks)
