### PR TITLE
Update role descriptions

### DIFF
--- a/handbook/recruitment/designer.md
+++ b/handbook/recruitment/designer.md
@@ -14,9 +14,9 @@ As a designer at UBC Launch Pad, you will be working with other designers and de
 Learn more about us on our [website](https://ubclaunchpad.com/) or our [club manifesto](https://docs.ubclaunchpad.com/handbook/manifesto), which includes our vision and code of conduct. You can also learn about how recruitment works in Launch Pad in our [recruitment overview](/handbook/recruitment/overview.md).
 
 <!-- Comment out when accepting applications, also uncomment the form at the bottom -->
-::: warning We are not currently accepting applications for this role.
+<!-- ::: warning We are not currently accepting applications for this role.
 Sign up for our [newsletter](https://ubclaunchpad.com/newsletter) to get updates!
-:::
+::: -->
 
 ## Responsibilities
 
@@ -37,8 +37,8 @@ Sign up for our [newsletter](https://ubclaunchpad.com/newsletter) to get updates
 
 ## Time commitment
 
-* September 12th (TBD) - semester kickoff
-* Weekly team meetings (1 hour per week) and occasional club meetings
+* Club meetings every other Saturday from 12pm-3pm (the first hour is required, the rest of the time is to hang out, work, and eat lunch together and we highly recommend staying if you can!)
+* 1 hour bi-weekly sub-team meetings (alternating with the club-wide Saturday meetings) that are scheduled based on sub-team member availability
 * Around 5 hours per week working on tasks
 
 ## Requirements

--- a/handbook/recruitment/designer.md
+++ b/handbook/recruitment/designer.md
@@ -5,7 +5,7 @@ search: false
 
 # Designer 🚀 <img align="right" src="https://raw.githubusercontent.com/ubclaunchpad/ubclaunchpad.com/master/src/assets/rocket.png" width="100px">
 
-> UBC Launch Pad 2020 Team
+> UBC Launch Pad 2021 Team
 
 ## Summary
 

--- a/handbook/recruitment/developer.md
+++ b/handbook/recruitment/developer.md
@@ -5,7 +5,7 @@ search: false
 
 # Developer 🚀 <img align="right" src="https://raw.githubusercontent.com/ubclaunchpad/ubclaunchpad.com/master/src/assets/rocket.png" width="100px">
 
-> UBC Launch Pad 2020 Team
+> UBC Launch Pad 2021 Team
 
 ## Summary
 
@@ -14,9 +14,9 @@ As a developer at UBC Launch Pad, you will be working with other developers and 
 Learn more about us on our [website](https://ubclaunchpad.com/) or our [club manifesto](https://docs.ubclaunchpad.com/handbook/manifesto), which includes our vision and code of conduct. You can also learn about how recruitment works in Launch Pad in our [recruitment overview](/handbook/recruitment/overview.md).
 
 <!-- Comment out when accepting applications, also uncomment the form at the bottom -->
-::: warning We are not currently accepting applications for this role.
+<!-- ::: warning We are not currently accepting applications for this role.
 Sign up for our [newsletter](https://ubclaunchpad.com/newsletter) to get updates!
-:::
+::: -->
 
 ## Responsibilities
 
@@ -35,8 +35,8 @@ Sign up for our [newsletter](https://ubclaunchpad.com/newsletter) to get updates
 
 ## Time commitment
 
-* September 12th (TBD) - semester kickoff
-* Weekly team meetings (1 hour per week) and occasional club meetings
+* Club meetings every other Saturday from 12pm-3pm (the first hour is required, the rest of the time is to hang out, work, and eat lunch together and we highly recommend staying if you can!)
+* 1 hour bi-weekly sub-team meetings (alternating with the club-wide Saturday meetings) that are scheduled based on sub-team member availability
 * Around 5 hours per week working on tasks
 
 ## Requirements


### PR DESCRIPTION
* Removed warning that we're not accepting applications for developers and designers (I chose not to uncomment the "we're currently accepting applications" tip because we're definitely going to forget to remove that, and I think it's very unlikely that a prospective member gets here without first seeing the application section on our website)
* Updated the time commitment to reflect our hybrid meeting model